### PR TITLE
Moved <style> section

### DIFF
--- a/catalog/view/theme/default/template/opentshirts/product.tpl
+++ b/catalog/view/theme/default/template/opentshirts/product.tpl
@@ -1,4 +1,5 @@
 <?php echo $header; ?><?php echo $column_left; ?><?php echo $column_right; ?>
+<div id="content"><?php echo $content_top; ?>
 <style type="text/css">
 #ot_title_text {
     font-weight: bold;
@@ -42,7 +43,6 @@
     text-align: center;
 }
 </style>
-<div id="content"><?php echo $content_top; ?>
   <div class="breadcrumb">
     <?php foreach ($breadcrumbs as $breadcrumb) { ?>
     <?php echo $breadcrumb['separator']; ?><a href="<?php echo $breadcrumb['href']; ?>"><?php echo $breadcrumb['text']; ?></a>


### PR DESCRIPTION
The style tags placed between 

``` php
<?php echo $header; ?><?php echo $column_left; ?><?php echo $column_right; ?>
```

and

```
<div id="content"><?php echo $content_top; ?>
```

cause the default CSS properties of 

```
#column-left + #column-right + #content, #column-left + #content{
```

to be ignored.  Page layout is displayed incorrectly as a result.

Moving the style tags below the content div seems to fix the problem.
